### PR TITLE
DEV: Only show custom SSO signup button if the DiscourseConnect enabled

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -5,16 +5,18 @@
       .mobile-view & {
         display: none;
       }
-    }   
+    }
+    // Hide the default signup button when the custom signup button available
     ~ .auth-buttons {
       .sign-up-button {
-        display: flex;
+        display: none;
       }
     }
   }
+  // Show the default signup button when the custom signup button not available
   .auth-buttons {
     .sign-up-button {
-      display: none;
+      display: flex;
     }
   }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,15 +1,20 @@
 .d-header {
-  .auth-buttons {
-    .sign-up-button:not(.sso-signup-button) {
-      display: none;
-    }
-  }
   .sso-signup-button {
     margin-left: 7px;
     @if $hide-sso-signup-button-on-mobile == "true" {
       .mobile-view & {
         display: none;
       }
+    }   
+    ~ .auth-buttons {
+      .sign-up-button {
+        display: flex;
+      }
+    }
+  }
+  .auth-buttons {
+    .sign-up-button {
+      display: none;
     }
   }
 }

--- a/javascripts/discourse/api-initializers/sso-signup.gjs
+++ b/javascripts/discourse/api-initializers/sso-signup.gjs
@@ -5,8 +5,9 @@ import { i18n } from "discourse-i18n";
 
 export default apiInitializer("1.14.0", (api) => {
   const currentUser = api.getCurrentUser();
+  const siteSettings = api.container.lookup("service:site-settings");
 
-  if (currentUser) {
+  if (currentUser && !siteSettings.enable_discourse_connect) {
     return;
   }
 

--- a/javascripts/discourse/api-initializers/sso-signup.gjs
+++ b/javascripts/discourse/api-initializers/sso-signup.gjs
@@ -7,10 +7,6 @@ export default apiInitializer("1.14.0", (api) => {
   const currentUser = api.getCurrentUser();
   const siteSettings = api.container.lookup("service:site-settings");
 
-  if (currentUser && !siteSettings.enable_discourse_connect) {
-    return;
-  }
-
   const signUpSsoButton = <template>
     <DButton
       class="btn-primary btn-small sign-up-button sso-signup-button"
@@ -19,9 +15,11 @@ export default apiInitializer("1.14.0", (api) => {
     />
   </template>
 
-  api.headerButtons.add(
-    "sso-signup",
-    signUpSsoButton,
-    { before: "auth" }
-  )
+  if (!currentUser && siteSettings.enable_discourse_connect) {
+    api.headerButtons.add(
+      "sso-signup",
+      signUpSsoButton,
+      { before: "auth" }
+    )
+  }
 });


### PR DESCRIPTION
It will hide the default SignUp button when the custom Signup button appears. The custom button only appears when the DiscourseConnect enabled.